### PR TITLE
mark only @openzeppelin/contracts as non-dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,14 @@
 {
+  "name": "erc721ra",
+  "version": "1.0.0-beta.1",
+  "description": "",
   "dependencies": {
+    "@openzeppelin/contracts": "^4.6.0"
+  },
+  "devDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.0.6",
     "@nomiclabs/hardhat-etherscan": "^3.0.3",
     "@nomiclabs/hardhat-waffle": "^2.0.3",
-    "@openzeppelin/contracts": "^4.6.0",
     "chai": "^4.3.6",
     "dotenv": "^16.0.1",
     "ethereum-waffle": "^3.4.4",
@@ -11,5 +16,9 @@
     "hardhat": "^2.9.5",
     "hardhat-gas-reporter": "^1.0.8",
     "solidity-coverage": "^0.7.21"
-  }
+  },
+  "bugs": {
+    "url": "https://github.com/ERC721RA/erc721ra/issues"
+  },
+  "homepage": "https://erc721ra.org"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -578,7 +578,7 @@
     "@types/sinon-chai" "^3.2.3"
     "@types/web3" "1.0.19"
 
-"@openzeppelin/contracts@^4.4.2", "@openzeppelin/contracts@^4.6.0":
+"@openzeppelin/contracts@^4.6.0":
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.6.0.tgz#c91cf64bc27f573836dba4122758b4743418c1b3"
   integrity sha512-8vi4d50NNya/bQqCmaVzvHNmwHvS0OBKb7HNtuNwEE3scXWrP31fKQoGxNMT+KbzmrNZzatE3QK5p2gFONI/hg==
@@ -2945,13 +2945,6 @@ env-paths@^2.2.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/env-paths/-/env-paths-2.2.1.tgz#420399d416ce1fbe9bc0a07c62fa68d67fd0f8f2"
   integrity sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==
-
-erc721a@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/erc721a/-/erc721a-3.3.0.tgz#ff0fa7880759766ae44916fb7f53eb178e14b044"
-  integrity sha512-LqwmMcDPS3H9y7ZO+9B7R9sEoWApra17d4PwodXuP1072jP653jdo0TYkJbK4G5pBUFDdB5TCZwmJ6EQbmrysQ==
-  dependencies:
-    "@openzeppelin/contracts" "^4.4.2"
 
 errno@~0.1.1:
   version "0.1.8"


### PR DESCRIPTION
We don't need dev dependencies for users add us to their own package.json dependencies.